### PR TITLE
Revise expert agent

### DIFF
--- a/src/infrastructure/beam_search.py
+++ b/src/infrastructure/beam_search.py
@@ -90,7 +90,7 @@ class BeamSearch:
             if qubit is None:
                 costs = env.entropy().mean(axis=-1)
             else:
-                costs = env.Entropy(next_states)[:, qubit]
+                costs = env.entropy()[:, qubit]
             imincost = np.argmin(costs)
             mincost = costs[imincost]
             # Check if a goal state is reached


### PR DESCRIPTION
Fixed slowdown in the updated Beam Search.

The slowdown was caused from calls to static method `Entropy()` instead of
member `entropy()`. This resulted in 2x more calls to `numpy.linalg.svd()`,
because entropies were recalculated (instead of returning the cached ones).
